### PR TITLE
Refactor frontmatter sync and lazy patcher registration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ When `settings.enableFrontmatter` is on, plugin writes:
 1. `canvas: [[<canvas-name>]]` on every referenced note.
 2. A property named after each canvas's basename, holding links to edge-connected nodes.
 
-Mutation functions early-return if disabled, and check the metadata cache first to skip `processFrontMatter` calls that would be no-ops — keep that pattern when adding writes. The auto-link edge patch only queues a sync when an edge's endpoints change (geometry-only `edge.update()` calls are ignored).
+Mutation functions early-return if disabled, and check the metadata cache first to skip `processFrontMatter` calls that would be no-ops — keep that pattern when adding writes. Property order matters: `canvas` must precede the per-canvas properties; every write path calls `ensureCanvasKeyOrder` inside its `processFrontMatter` callback to enforce this (writes race, so insertion order alone isn't enough). The auto-link edge patch only queues a sync when an edge's endpoints change (geometry-only `edge.update()` calls are ignored). All edge syncs — including `addEdge` — go through the debounced queue, never immediately: opening a canvas re-adds every edge, and a sync mid-import sees partial canvas data and strips valid links. The metadata cache only gates whether a sync runs at all; the actual add/remove decisions happen inside the `processFrontMatter` callback against the real frontmatter, because the cache lags right after a write.
 
 **Invariant: cleanup must run *before* flipping the setting off**, else `removeProperty` no-ops. Settings tab handler enforces this — preserve it.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,17 +18,9 @@ Features are `register*` methods called from `onload()` (see `main.ts:445-453`):
 
 ### Prototype patching (load-bearing)
 
-Uses `monkey-around`'s `around()`. Canvas internals are reverse-engineered in `Canvas.d.ts`. Patching needs a Canvas leaf, so every patcher uses:
+Uses `monkey-around`'s `around()`. Canvas internals are reverse-engineered in `Canvas.d.ts`. Patching needs a Canvas leaf, so every patcher goes through `EnhancedCanvas.registerLazyPatcher(patch)`: it retries `patch()` (which returns success) on `active-leaf-change`/`layout-change`/`onLayoutReady` and detaches the retry listeners after the first success.
 
-```ts
-const tryToPatch = () => { if (patch()) detachListeners(); };
-plugin.app.workspace.on('active-leaf-change', tryToPatch);
-plugin.app.workspace.on('layout-change', tryToPatch);
-plugin.app.workspace.onLayoutReady(tryToPatch);
-tryToPatch();
-```
-
-Touching this broke Windows pinned tabs before (commit `742eb70`). **Detach listeners after a successful patch** — leaving them attached re-patches and breaks things. Register every uninstaller with `this.register(...)`.
+Touching this broke Windows pinned tabs before (commit `742eb70`). **Don't hand-roll the retry pattern — use the helper**, which guarantees listeners detach after a successful patch (leaving them attached re-patches and breaks things). Register every uninstaller with `this.register(...)`.
 
 ### Two node concepts — don't mix
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Obsidian plugin (`isDesktopOnly: false`). Entry `main.ts` → `main.js` via `esb
 
 ### `main.ts` — `EnhancedCanvas`
 
-Features are `register*` methods called from `onload()` (see `main.ts:445-453`): plugin commands, canvas auto-link, file-manager patches, focus-canvas, exploder, tag import, node auto-height, default node size, drag-temp-node. `onload` walks every `.canvas` to bulk-add properties; `onunload` strips them.
+Features are `register*` methods called from `onload()` (see `main.ts:445-453`): plugin commands, canvas auto-link, file-manager patches, focus-canvas, exploder, tag import, node auto-height, default node size, drag-temp-node. `onload` runs `syncAllCanvasProperties`: it aggregates the desired frontmatter across all `.canvas` files, diffs against the metadata cache, and does at most one `processFrontMatter` write per out-of-date note (zero writes when nothing changed — keep it that way). `onunload` strips the properties.
 
 ### Prototype patching (load-bearing)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,9 @@ When `settings.enableFrontmatter` is on, plugin writes:
 1. `canvas: [[<canvas-name>]]` on every referenced note.
 2. A property named after each canvas's basename, holding links to edge-connected nodes.
 
-Mutation functions early-return if disabled. **Invariant: cleanup must run *before* flipping the setting off**, else `removeProperty` no-ops. Settings tab handler enforces this — preserve it.
+Mutation functions early-return if disabled, and check the metadata cache first to skip `processFrontMatter` calls that would be no-ops — keep that pattern when adding writes. The auto-link edge patch only queues a sync when an edge's endpoints change (geometry-only `edge.update()` calls are ignored).
+
+**Invariant: cleanup must run *before* flipping the setting off**, else `removeProperty` no-ops. Settings tab handler enforces this — preserve it.
 
 ### `src/` modules
 

--- a/main.ts
+++ b/main.ts
@@ -23,7 +23,6 @@ import { ReleaseNotesModal } from "./src/ReleaseNotesModal";
 
 interface CanvasNodeWithFlag extends CanvasNode {
     _autoHeightTimer?: number | null;
-    _delayedResizeTimer?: number | null;
     autoHeightEnabled?: boolean;
     onResizeDblclick(event: unknown, direction: string): void;
 }
@@ -52,11 +51,15 @@ function frontmatterValueToArray(value: unknown): string[] {
 	return [];
 }
 
+/** Escapes regex metacharacters so file names can be embedded in a RegExp. */
+function escapeRegExp(text: string): string {
+	return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 export default class EnhancedCanvas extends Plugin {
 	public exploder: CanvasExploder;
 	public sendToCanvas: SendToCanvas;
 	public canvasTagImport: CanvasTagImport;
-	public patchedEdge: boolean;
 	private isMetadataClicked = false;
 	settings: EnhancedCanvasSettings;
 
@@ -458,7 +461,7 @@ export default class EnhancedCanvas extends Plugin {
         }); 
     };
 
-	private ifActiveViewIsCanvas = (commandFn: (canvas: Canvas, canvasData: CanvasData) => void) => (checking: boolean) => {
+	private ifActiveViewIsCanvas = (commandFn: (canvas: Canvas) => void) => (checking: boolean) => {
 		const activeView = this.app.workspace.getActiveViewOfType(ItemView);
 		if (activeView?.getViewType() !== 'canvas') {
 			return checking ? false : undefined;
@@ -467,10 +470,8 @@ export default class EnhancedCanvas extends Plugin {
 		if (checking) return true;
 
 		const canvas = (activeView as CanvasView).canvas;
-		const canvasData = canvas?.getData();
-
-		if (!canvas || !canvasData) return;
-		return commandFn(canvas, canvasData);
+		if (!canvas) return;
+		return commandFn(canvas);
 	}
 
 	/** Applies or removes the body CSS class that gates the optional visual styles. */
@@ -613,8 +614,8 @@ export default class EnhancedCanvas extends Plugin {
 			const backLinks = this.app.metadataCache.getBacklinksForFile(file);
 			if (!backLinks || !backLinks.data) return;
 
-			const linkRegexBasename = new RegExp(`\\[\\[${file.basename}(\\|.*)?\\]\\]`);
-			const linkRegexFullName = new RegExp(`\\[\\[${file.name}(\\|.*)?\\]\\]`);
+			const linkRegexBasename = new RegExp(`\\[\\[${escapeRegExp(file.basename)}(\\|.*)?\\]\\]`);
+			const linkRegexFullName = new RegExp(`\\[\\[${escapeRegExp(file.name)}(\\|.*)?\\]\\]`);
 
 			for (const [sourcePath] of backLinks.data.entries()) {
 				const sourceFile = this.app.vault.getFileByPath(sourcePath);
@@ -696,7 +697,7 @@ export default class EnhancedCanvas extends Plugin {
 		this.addCommand({
 			id: 'optimize-edges',
 			name: 'Adjust edges with shortest path',
-			checkCallback: this.ifActiveViewIsCanvas((canvas, canvasData) => {
+			checkCallback: this.ifActiveViewIsCanvas((canvas) => {
 				this.optimizeEdgesBetweenSelectedNodes(canvas);
 			})
 		});
@@ -704,7 +705,7 @@ export default class EnhancedCanvas extends Plugin {
 		this.addCommand({
 			id: 'delete-edges',
 			name: 'Delete edges between selected nodes',
-			checkCallback: this.ifActiveViewIsCanvas((canvas, canvasData) => {
+			checkCallback: this.ifActiveViewIsCanvas((canvas) => {
 				this.deleteEdges(canvas);
 			})
 		});
@@ -712,7 +713,7 @@ export default class EnhancedCanvas extends Plugin {
 		this.addCommand({
 			id: 'add-link-and-optimize-edge',
 			name: 'Add edges according the links in notes',
-			checkCallback: this.ifActiveViewIsCanvas((canvas, canvasData) => {
+			checkCallback: this.ifActiveViewIsCanvas((canvas) => {
 				this.createMissingEdgesFromLinks(canvas);
 				this.optimizeEdgesBetweenSelectedNodes(canvas);
 			})
@@ -721,8 +722,8 @@ export default class EnhancedCanvas extends Plugin {
 		this.addCommand({
 			id: 'remove-canvas-property',
 			name: 'Remove the property of all nodes in current Canvas',
-			checkCallback: this.ifActiveViewIsCanvas((canvas, canvasData) => {
-				void this.removeAllProperty(canvas, canvasData);
+			checkCallback: this.ifActiveViewIsCanvas((canvas) => {
+				void this.removeAllProperty(canvas, canvas.getData());
 			})
 		});
 

--- a/main.ts
+++ b/main.ts
@@ -43,6 +43,15 @@ interface JsonNodeRef {
     [key: string]: unknown;
 }
 
+/** Normalizes a frontmatter value (missing, string, or array) to a string array. */
+function frontmatterValueToArray(value: unknown): string[] {
+	if (Array.isArray(value)) {
+		return value.filter((item): item is string => typeof item === 'string' && item.trim() !== '');
+	}
+	if (typeof value === 'string' && value.trim() !== '') return [value];
+	return [];
+}
+
 export default class EnhancedCanvas extends Plugin {
 	public exploder: CanvasExploder;
 	public sendToCanvas: SendToCanvas;
@@ -169,17 +178,22 @@ export default class EnhancedCanvas extends Plugin {
 		const file = this.app.vault.getFileByPath(node.file); // node is JSON node, not canvas node
 		if (!file) return;
 
+		const canvasLink = `[[${propertyName}]]`;
+
+		// Skip the write when the cached frontmatter already carries both properties.
+		const cached = this.app.metadataCache.getFileCache(file)?.frontmatter;
+		if (cached && cached[basename] && frontmatterValueToArray(cached.canvas).includes(canvasLink)) return;
+
 		void this.app.fileManager.processFrontMatter(file, (frontmatter) => {
 			if (!frontmatter) return;
 
 			if (!frontmatter.canvas) {
 				frontmatter.canvas = [];
 			}
-			const canvasLink = `[[${propertyName}]]`;
 			if (!frontmatter.canvas.includes(canvasLink)) {
 				frontmatter.canvas.push(canvasLink);
 			}
-	
+
 			if (!frontmatter[basename]) {
 				frontmatter[basename] = [];
 			}
@@ -195,6 +209,11 @@ export default class EnhancedCanvas extends Plugin {
 		const file = this.app.vault.getFileByPath(node.file); // node is JSON node, not canvas node
 		if (!file) return;
 
+		// Skip the write when the cached frontmatter has nothing to remove.
+		const canvasLink = `[[${propertyName}]]`;
+		const cached = this.app.metadataCache.getFileCache(file)?.frontmatter;
+		if (!cached || (!(basename in cached) && !frontmatterValueToArray(cached.canvas).includes(canvasLink))) return;
+
 		return this.app.fileManager.processFrontMatter(file, (frontmatter) => {
 			if (!frontmatter) return;
 	
@@ -205,7 +224,6 @@ export default class EnhancedCanvas extends Plugin {
 	
 			// remove the link from the canvas property
 			if (frontmatter.canvas) {
-				const canvasLink = `[[${propertyName}]]`;
 				frontmatter.canvas = frontmatter.canvas.filter((link: string) => link !== canvasLink);
 
 				if (frontmatter.canvas.length === 0) {
@@ -259,29 +277,6 @@ export default class EnhancedCanvas extends Plugin {
 		canvas.setData(canvasData);
 		canvas.requestSave(false);
 	}
-
-	async processEdgeUpdate(e: CanvasEdge) {
-		if (!this.settings.enableFrontmatter) return;
-        const fromNode = e?.from?.node;
-        const toNode = e?.to?.node;
-
-        if (!fromNode || !toNode) return;
-
-        const fromFilePath = fromNode.filePath ?? fromNode.file?.path;
-        const toFilePath = toNode.filePath ?? toNode.file?.path;
-        if (!fromFilePath || !toFilePath) return;
-
-        const fromFile = this.app.vault.getFileByPath(fromFilePath);
-        const toFile = this.app.vault.getFileByPath(toFilePath);
-
-		if (fromFilePath === toFilePath) return;
-        if (!fromFile || !toFile) return;
-
-        const canvasName = e.canvas.view.file.basename;
-
-        const link = this.app.fileManager.generateMarkdownLink(toFile, fromFilePath).replace(/^!(\[\[.*\]\])$/, '$1');
-        await this.updateFrontmatter(fromFile, link, 'add', canvasName);
-    }
 
 	/**
 	 * Startup sweep: ensures every markdown note referenced by a canvas carries
@@ -365,14 +360,6 @@ export default class EnhancedCanvas extends Plugin {
 			}
 		}));
 
-		const toStringArray = (value: unknown): string[] => {
-			if (Array.isArray(value)) {
-				return value.filter((item): item is string => typeof item === 'string' && item.trim() !== '');
-			}
-			if (typeof value === 'string' && value.trim() !== '') return [value];
-			return [];
-		};
-
 		await Promise.all(Array.from(desiredByPath.entries()).map(async ([path, desired]) => {
 			const file = this.app.vault.getFileByPath(path);
 			// processFrontMatter only works on markdown notes; skip everything else.
@@ -380,12 +367,12 @@ export default class EnhancedCanvas extends Plugin {
 
 			const cached = this.app.metadataCache.getFileCache(file)?.frontmatter;
 			if (cached) {
-				const cachedCanvas = toStringArray(cached.canvas);
+				const cachedCanvas = frontmatterValueToArray(cached.canvas);
 				const upToDate =
 					Array.from(desired.canvasLinks).every(link => cachedCanvas.includes(link)) &&
 					Array.from(desired.ensureKeys).every(key => !!cached[key]) &&
 					Array.from(desired.linksByKey.entries()).every(([key, links]) => {
-						const existing = toStringArray(cached[key]);
+						const existing = frontmatterValueToArray(cached[key]);
 						return Array.from(links).every(link => existing.includes(link));
 					});
 				if (upToDate) return;
@@ -417,7 +404,7 @@ export default class EnhancedCanvas extends Plugin {
 					for (const [key, links] of desired.linksByKey) {
 						const existingValue = Reflect.get(frontmatter, key);
 						const wasString = typeof existingValue === 'string' && existingValue.trim() !== '';
-						const merged = toStringArray(existingValue);
+						const merged = frontmatterValueToArray(existingValue);
 						for (const link of links) {
 							if (!merged.includes(link)) {
 								merged.push(link);
@@ -877,26 +864,34 @@ export default class EnhancedCanvas extends Plugin {
 
 			const updatePromises: Promise<void>[] = [];
 			const getFilePath = (path: string) => this.app.vault.getFileByPath(path);
-		
+
+			// Links the property currently holds per the metadata cache; lets
+			// removes/adds that would be no-ops skip processFrontMatter entirely.
+			const cachedLinks = frontmatterValueToArray(
+				this.app.metadataCache.getFileCache(fromFile)?.frontmatter?.[canvasName]
+			);
+
 			fromNodeLinks.forEach(filePath => {
 				if (!edgeToNodesFilePathSet.has(filePath)) {
 					if (filePath === e.canvas.view.file.path) return;
 					const targetFile = getFilePath(filePath);
 					if (!targetFile) return;
-		
+
 					const link = this.app.fileManager.generateMarkdownLink(targetFile, filePath).replace(/^!(\[\[.*\]\])$/, '$1');
+					if (!cachedLinks.includes(link)) return;
 					updatePromises.push(this.updateFrontmatter(fromFile, link, 'remove', canvasName));
 				}
 			});
-		
+
 			if (toNode?.filePath) {
 				if (fromNode.filePath !== toNode.filePath) {
 					const targetFile = getFilePath(toNode.filePath);
-					
+
 					if (targetFile) {
 						const link = this.app.fileManager.generateMarkdownLink(targetFile, toNode.filePath).replace(/^!(\[\[.*\]\])$/, '$1');
-						// 將此操作加入 Promise 佇列
-						updatePromises.push(this.updateFrontmatter(fromFile, link, 'add', canvasName));
+						if (!cachedLinks.includes(link)) {
+							updatePromises.push(this.updateFrontmatter(fromFile, link, 'add', canvasName));
+						}
 					}
 				}
 			}
@@ -904,9 +899,35 @@ export default class EnhancedCanvas extends Plugin {
 			await Promise.all(updatePromises);
 		};
 
-		const updateTargetNode = debounce((e: CanvasEdge) => {
-			void processNodeUpdate(e);
+		// Edges touched within the debounce window all get processed; repeated
+		// updates of the same edge collapse into one slot.
+		const pendingEdgeUpdates = new Set<CanvasEdge>();
+		const flushEdgeUpdates = debounce(() => {
+			const pending = Array.from(pendingEdgeUpdates);
+			pendingEdgeUpdates.clear();
+			for (const edge of pending) {
+				void processNodeUpdate(edge);
+			}
 		}, 500, true);
+
+		// edge.update() fires on every geometric change (node drag, pan, layout),
+		// but the frontmatter sync only depends on what the edge connects. Track
+		// each edge's endpoints and queue a sync only when they change. The first
+		// sighting is the baseline: new edges are already synced by the addEdge
+		// patch below.
+		const edgeConnectivity = new WeakMap<CanvasEdge, string>();
+		const updateTargetNode = (e: CanvasEdge) => {
+			const connectivity =
+				`${e.from?.node?.id ?? ''}:${e.from?.node?.filePath ?? ''}` +
+				`->${e.to?.node?.id ?? ''}:${e.to?.node?.filePath ?? ''}`;
+			const previous = edgeConnectivity.get(e);
+			if (previous === connectivity) return;
+			edgeConnectivity.set(e, connectivity);
+			if (previous === undefined) return;
+
+			pendingEdgeUpdates.add(e);
+			flushEdgeUpdates();
+		};
 
 		const updateTargetNodeImmediate = async (e: CanvasEdge) => {
 			await processNodeUpdate(e);

--- a/main.ts
+++ b/main.ts
@@ -120,11 +120,16 @@ export default class EnhancedCanvas extends Plugin {
 
 		const selectedNodeIds = new Set(selectedNodes.map((node) => node.id));
 
+		const nodeById = new Map<string, CanvasNodeData>();
+		for (const node of currentData.nodes) {
+			nodeById.set(node.id, node);
+		}
+
 		let didUpdateEdges = false;
 		currentData.edges.forEach((edge: CanvasEdgeData) => {
 			if (selectedNodeIds.has(edge.fromNode) && selectedNodeIds.has(edge.toNode)) {
-				const fromNode = currentData.nodes.find((node: CanvasNodeData) => node.id === edge.fromNode);
-				const toNode = currentData.nodes.find((node: CanvasNodeData) => node.id === edge.toNode);
+				const fromNode = nodeById.get(edge.fromNode);
+				const toNode = nodeById.get(edge.toNode);
 				if (fromNode && toNode) {
 					const updatedEdge = this.createEdge(fromNode, toNode);
 					if (edge.fromSide !== updatedEdge.fromSide || edge.toSide !== updatedEdge.toSide) {
@@ -279,86 +284,152 @@ export default class EnhancedCanvas extends Plugin {
     }
 
 	/**
-	 * Orchestrates a batch update for all connections within the provided canvas data
-	 * to ensure every edge is validated and processed according to the plugin's
-	 * current update logic.
+	 * Startup sweep: ensures every markdown note referenced by a canvas carries
+	 * the plugin's frontmatter properties (the `canvas` link list plus one
+	 * property per canvas holding links to edge-connected notes).
+	 *
+	 * The desired state is aggregated across all canvases first, then compared
+	 * against the metadata cache, so each note gets at most one
+	 * `processFrontMatter` write — and none at all when it is already up to
+	 * date, which is the common case on restart.
 	 */
-	async processEdgesInCanvas(canvasData: CanvasData, canvasFile: TFile) {
-		if (!canvasData || !this.settings.enableFrontmatter) return;
-	
-		const nodeIdToNodeMap = new Map<string, CanvasNodeData>();
+	async syncAllCanvasProperties() {
+		if (!this.settings.enableFrontmatter) return;
 
-		if (canvasData.nodes && Array.isArray(canvasData.nodes)) {
-			for (const node of canvasData.nodes) {
-				nodeIdToNodeMap.set(node.id, node);
-			}
+		interface DesiredProps {
+			/** Entries the `canvas` property must contain, e.g. '[[Name.canvas]]'. */
+			canvasLinks: Set<string>;
+			/** Per-canvas properties (canvas basenames) that must exist. */
+			ensureKeys: Set<string>;
+			/** Links each per-canvas property must contain. */
+			linksByKey: Map<string, Set<string>>;
 		}
-	
-		const fileLinksToAdd = new Map<string, Set<string>>();
+		const desiredByPath = new Map<string, DesiredProps>();
+		const getDesired = (path: string): DesiredProps => {
+			let desired = desiredByPath.get(path);
+			if (!desired) {
+				desired = { canvasLinks: new Set(), ensureKeys: new Set(), linksByKey: new Map() };
+				desiredByPath.set(path, desired);
+			}
+			return desired;
+		};
 
-		if (canvasData.edges && Array.isArray(canvasData.edges)) {
-			for (const edgeData of canvasData.edges) {
-				const fromNode = nodeIdToNodeMap.get(edgeData.fromNode);
-				const toNode = nodeIdToNodeMap.get(edgeData.toNode);
-	
-				if (!fromNode || !toNode) continue;
+		const canvasFiles = this.app.vault.getFiles().filter(file => file.extension === 'canvas');
 
-				const fromFilePath = fromNode.file;
-				const toFilePath = toNode.file;
+		await Promise.all(canvasFiles.map(async (canvasFile) => {
+			let canvasData: CanvasData;
+			try {
+				const content = await this.app.vault.read(canvasFile);
+				if (!content || content.trim() === '') return;
+				canvasData = JSON.parse(content) as CanvasData;
+			} catch (error) {
+				console.error("Enhanced Canvas: Failed to read canvas file", canvasFile.path, error);
+				return;
+			}
+			if (!canvasData) return;
 
-				if (!fromFilePath || !toFilePath) continue;
-		
-				const fromFile = this.app.vault.getFileByPath(fromFilePath);
-				const toFile = this.app.vault.getFileByPath(toFilePath);
-		
-				if (fromFilePath === toFilePath) continue;
-				if (!fromFile || !toFile) continue;
-		
-				const link = this.app.fileManager.generateMarkdownLink(toFile, fromFilePath).replace(/^!(\[\[.*\]\])$/, '$1');
-				
-				if (!fileLinksToAdd.has(fromFilePath)) {
-					fileLinksToAdd.set(fromFilePath, new Set());
+			const nodes = Array.isArray(canvasData.nodes) ? canvasData.nodes : [];
+			const edges = Array.isArray(canvasData.edges) ? canvasData.edges : [];
+
+			const nodeById = new Map<string, CanvasNodeData>();
+			for (const node of nodes) {
+				nodeById.set(node.id, node);
+			}
+
+			for (const node of nodes) {
+				if (!node?.file) continue;
+				const desired = getDesired(node.file);
+				desired.canvasLinks.add(`[[${canvasFile.name}]]`);
+				desired.ensureKeys.add(canvasFile.basename);
+			}
+
+			for (const edgeData of edges) {
+				const fromNode = nodeById.get(edgeData.fromNode);
+				const toNode = nodeById.get(edgeData.toNode);
+
+				if (!fromNode?.file || !toNode?.file) continue;
+				if (fromNode.file === toNode.file) continue;
+
+				const toFile = this.app.vault.getFileByPath(toNode.file);
+				if (!toFile) continue;
+
+				const link = this.app.fileManager.generateMarkdownLink(toFile, fromNode.file).replace(/^!(\[\[.*\]\])$/, '$1');
+
+				const desired = getDesired(fromNode.file);
+				let links = desired.linksByKey.get(canvasFile.basename);
+				if (!links) {
+					links = new Set();
+					desired.linksByKey.set(canvasFile.basename, links);
 				}
-				fileLinksToAdd.get(fromFilePath)!.add(link);
+				links.add(link);
 			}
-		}
+		}));
 
-		const canvasName = canvasFile.basename;
-		for (const [fromFilePath, links] of fileLinksToAdd.entries()) {
-			const fromFile = this.app.vault.getFileByPath(fromFilePath);
-			if (fromFile) {
-				await this.app.fileManager.processFrontMatter(fromFile, (fm) => {
-					const existingValue = Reflect.get(fm, canvasName);
-					const currentSet = new Set<string>();
-					let wasString = false;
+		const toStringArray = (value: unknown): string[] => {
+			if (Array.isArray(value)) {
+				return value.filter((item): item is string => typeof item === 'string' && item.trim() !== '');
+			}
+			if (typeof value === 'string' && value.trim() !== '') return [value];
+			return [];
+		};
 
-					if (Array.isArray(existingValue)) {
-						existingValue
-							.filter((item): item is string => typeof item === 'string' && item.trim() !== '')
-							.forEach(item => currentSet.add(item));
-					} else if (typeof existingValue === 'string' && existingValue.trim() !== '') {
-						currentSet.add(existingValue);
-						wasString = true;
+		await Promise.all(Array.from(desiredByPath.entries()).map(async ([path, desired]) => {
+			const file = this.app.vault.getFileByPath(path);
+			// processFrontMatter only works on markdown notes; skip everything else.
+			if (!file || file.extension !== 'md') return;
+
+			const cached = this.app.metadataCache.getFileCache(file)?.frontmatter;
+			if (cached) {
+				const cachedCanvas = toStringArray(cached.canvas);
+				const upToDate =
+					Array.from(desired.canvasLinks).every(link => cachedCanvas.includes(link)) &&
+					Array.from(desired.ensureKeys).every(key => !!cached[key]) &&
+					Array.from(desired.linksByKey.entries()).every(([key, links]) => {
+						const existing = toStringArray(cached[key]);
+						return Array.from(links).every(link => existing.includes(link));
+					});
+				if (upToDate) return;
+			}
+
+			try {
+				await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
+					if (!frontmatter) return;
+
+					if (!frontmatter.canvas) {
+						frontmatter.canvas = [];
+					} else if (typeof frontmatter.canvas === 'string') {
+						frontmatter.canvas = [frontmatter.canvas];
 					}
-					
-					for (const link of links) {
-						currentSet.add(link);
-					}
-
-					const finalArray = Array.from(currentSet);
-
-					if (finalArray.length > 0) {
-						if (finalArray.length === 1 && wasString) {
-							Reflect.set(fm, canvasName, finalArray[0]);
-						} else {
-							Reflect.set(fm, canvasName, finalArray);
+					if (Array.isArray(frontmatter.canvas)) {
+						for (const link of desired.canvasLinks) {
+							if (!frontmatter.canvas.includes(link)) {
+								frontmatter.canvas.push(link);
+							}
 						}
-					} else {
-						Reflect.deleteProperty(fm, canvasName);
+					}
+
+					for (const key of desired.ensureKeys) {
+						if (!frontmatter[key]) {
+							frontmatter[key] = [];
+						}
+					}
+
+					for (const [key, links] of desired.linksByKey) {
+						const existingValue = Reflect.get(frontmatter, key);
+						const wasString = typeof existingValue === 'string' && existingValue.trim() !== '';
+						const merged = toStringArray(existingValue);
+						for (const link of links) {
+							if (!merged.includes(link)) {
+								merged.push(link);
+							}
+						}
+						Reflect.set(frontmatter, key, merged.length === 1 && wasString ? merged[0] : merged);
 					}
 				});
+			} catch (error) {
+				console.error("Enhanced Canvas: Failed to update properties for note", path, error);
 			}
-		}
+		}));
 	}
 
 	/**
@@ -451,35 +522,7 @@ export default class EnhancedCanvas extends Plugin {
 		this.registerCanvasDragTempNodePatcher();
 
 		try {
-			const canvasFiles = this.app.vault.getFiles().filter(file => file.extension === 'canvas');
-			
-			await Promise.all(canvasFiles.map(async (canvasFile) => {
-				try {
-					const content = await this.app.vault.read(canvasFile);
-					if (!content || content.trim() === '') return;
-					
-					try {
-						const canvasData = JSON.parse(content) as CanvasData;
-						if (!canvasData) return;
-						
-						if (canvasData.nodes && Array.isArray(canvasData.nodes)) {
-							for (const node of canvasData.nodes) {
-								if (!node?.file) continue;
-								
-								this.addProperty(node, canvasFile.name, canvasFile.basename);
-							}
-						}
-												
-						await this.processEdgesInCanvas(canvasData, canvasFile);
-					} catch (parseError) {
-						console.error("Enhanced Canvas: Failed to parse canvas data", parseError);
-						return;
-					}
-				} catch (fileError) {
-					console.error("Enhanced Canvas: Failed to read canvas file", fileError);
-					return;
-				}
-			}));
+			await this.syncAllCanvasProperties();
 		} catch (error) {
 			console.error("Enhanced Canvas: Error in metadata update loop", error);
 			return;
@@ -818,14 +861,17 @@ export default class EnhancedCanvas extends Plugin {
 
 			const { edges, nodes } = e.canvas.getData();
 
-			const sameFileNodeIds = new Set(
-				nodes.filter((node: CanvasNodeData) => node.file === fromNode.filePath).map((node: CanvasNodeData) => node.id)
-			);
-			const allRelevantEdges = edges.filter((edge: CanvasEdgeData) => sameFileNodeIds.has(edge.fromNode));
+			const nodeById = new Map<string, CanvasNodeData>();
+			const sameFileNodeIds = new Set<string>();
+			for (const node of nodes) {
+				nodeById.set(node.id, node);
+				if (node.file === fromNode.filePath) sameFileNodeIds.add(node.id);
+			}
 
 			const edgeToNodesFilePathSet = new Set<string>();
-			for (const edge of allRelevantEdges) {
-				const targetNode = nodes.find((node) => node.id === edge.toNode);
+			for (const edge of edges) {
+				if (!sameFileNodeIds.has(edge.fromNode)) continue;
+				const targetNode = nodeById.get(edge.toNode);
 				if (targetNode?.type === 'file') edgeToNodesFilePathSet.add(targetNode.file);
 			}
 
@@ -889,12 +935,14 @@ export default class EnhancedCanvas extends Plugin {
 			if (!fromFile) return;
 
 			const { edges, nodes } = edge.canvas.getData();
-			const sameFileNodes = nodes.filter((node: CanvasNodeData) => node.file === fromFilePath);
+			const sameFileNodeIds = new Set(
+				nodes.filter((node: CanvasNodeData) => node.file === fromFilePath).map((node: CanvasNodeData) => node.id)
+			);
 
 			const stillHasConnection = edges.some((e: CanvasEdgeData) =>
-				sameFileNodes.some((node: CanvasNodeData) => e.fromNode === node.id) &&
+				sameFileNodeIds.has(e.fromNode) &&
 				e.toNode === toNode.id &&
-				!(e.fromNode === fromNode.id && e.toNode === toNode.id)
+				e.fromNode !== fromNode.id
 			);
 
 			if (!stillHasConnection) {

--- a/main.ts
+++ b/main.ts
@@ -56,6 +56,30 @@ function escapeRegExp(text: string): string {
 	return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/**
+ * processFrontMatter serializes keys in object insertion order, so a per-canvas
+ * property created before the `canvas` property (e.g. by an edge sync racing the
+ * node-add sync) ends up above it in the YAML. Rebuilds the object so `canvas`
+ * sits just before the first per-canvas key, leaving other properties in place.
+ */
+function ensureCanvasKeyOrder(frontmatter: Record<string, unknown>, canvasKeys: Iterable<string>) {
+	const keys = Object.keys(frontmatter);
+	const canvasIndex = keys.indexOf('canvas');
+	if (canvasIndex === -1) return;
+
+	const targetKeys = new Set(canvasKeys);
+	targetKeys.delete('canvas');
+	const firstTargetIndex = keys.findIndex(key => targetKeys.has(key));
+	if (firstTargetIndex === -1 || canvasIndex < firstTargetIndex) return;
+
+	const values = { ...frontmatter };
+	const reordered = keys.filter(key => key !== 'canvas');
+	reordered.splice(reordered.indexOf(keys[firstTargetIndex]), 0, 'canvas');
+
+	for (const key of keys) delete frontmatter[key];
+	for (const key of reordered) frontmatter[key] = values[key];
+}
+
 export default class EnhancedCanvas extends Plugin {
 	public exploder: CanvasExploder;
 	public sendToCanvas: SendToCanvas;
@@ -197,6 +221,8 @@ export default class EnhancedCanvas extends Plugin {
 			if (!frontmatter[basename]) {
 				frontmatter[basename] = [];
 			}
+
+			ensureCanvasKeyOrder(frontmatter, [basename]);
 		});
 	}
 
@@ -368,9 +394,13 @@ export default class EnhancedCanvas extends Plugin {
 			const cached = this.app.metadataCache.getFileCache(file)?.frontmatter;
 			if (cached) {
 				const cachedCanvas = frontmatterValueToArray(cached.canvas);
+				const cachedKeys = Object.keys(cached);
+				const canvasKeyIndex = cachedKeys.indexOf('canvas');
 				const upToDate =
 					Array.from(desired.canvasLinks).every(link => cachedCanvas.includes(link)) &&
-					Array.from(desired.ensureKeys).every(key => !!cached[key]) &&
+					// The key must exist *and* sit below the `canvas` property in the YAML.
+					Array.from(desired.ensureKeys).every(key =>
+						!!cached[key] && canvasKeyIndex !== -1 && canvasKeyIndex < cachedKeys.indexOf(key)) &&
 					Array.from(desired.linksByKey.entries()).every(([key, links]) => {
 						const existing = frontmatterValueToArray(cached[key]);
 						return Array.from(links).every(link => existing.includes(link));
@@ -412,6 +442,8 @@ export default class EnhancedCanvas extends Plugin {
 						}
 						Reflect.set(frontmatter, key, merged.length === 1 && wasString ? merged[0] : merged);
 					}
+
+					ensureCanvasKeyOrder(frontmatter, desired.ensureKeys);
 				});
 			} catch (error) {
 				console.error("Enhanced Canvas: Failed to update properties for note", path, error);
@@ -455,7 +487,9 @@ export default class EnhancedCanvas extends Plugin {
             } else {
                 Reflect.deleteProperty(fm, propertyName);
             }
-        }); 
+
+            ensureCanvasKeyOrder(fm, [propertyName]);
+        });
     };
 
 	private ifActiveViewIsCanvas = (commandFn: (canvas: Canvas) => void) => (checking: boolean) => {
@@ -856,6 +890,8 @@ export default class EnhancedCanvas extends Plugin {
 	 */
 	registerCanvasAutoLink() {
 		const processNodeUpdate = async (e: CanvasEdge) => {
+			if (!this.settings.enableFrontmatter) return;
+
 			const fromNode = e?.from?.node;
 			const toNode = e?.to?.node;
 
@@ -865,7 +901,11 @@ export default class EnhancedCanvas extends Plugin {
 			const fromFile = this.app.vault.getFileByPath(fromNode.filePath);
 			if (!fromFile) return;
 
-			const canvasName = e.canvas.view.file.basename;
+			// The sync is debounced, so the canvas may have unloaded meanwhile.
+			const canvasFile = e.canvas?.view?.file;
+			if (!canvasFile) return;
+			const canvasName = canvasFile.basename;
+
 			const resolvedLinks = this.app.metadataCache.resolvedLinks[fromNode.filePath] || {};
 			const fromNodeLinks = Object.keys(resolvedLinks);
 
@@ -878,6 +918,11 @@ export default class EnhancedCanvas extends Plugin {
 				if (node.file === fromNode.filePath) sameFileNodeIds.add(node.id);
 			}
 
+			// Node gone from the canvas (closed or node deleted) — removeNodeUpdate
+			// owns that cleanup; reconciling against the now-empty data would
+			// wrongly strip every link.
+			if (!sameFileNodeIds.has(fromNode.id)) return;
+
 			const edgeToNodesFilePathSet = new Set<string>();
 			for (const edge of edges) {
 				if (!sameFileNodeIds.has(edge.fromNode)) continue;
@@ -885,45 +930,62 @@ export default class EnhancedCanvas extends Plugin {
 				if (targetNode?.type === 'file') edgeToNodesFilePathSet.add(targetNode.file);
 			}
 
-			const updatePromises: Promise<void>[] = [];
 			const getFilePath = (path: string) => this.app.vault.getFileByPath(path);
+			const toLink = (path: string, file: TFile) =>
+				this.app.fileManager.generateMarkdownLink(file, path).replace(/^!(\[\[.*\]\])$/, '$1');
 
-			// Links the property currently holds per the metadata cache; lets
-			// removes/adds that would be no-ops skip processFrontMatter entirely.
+			const linksToRemove: string[] = [];
+			fromNodeLinks.forEach(filePath => {
+				if (edgeToNodesFilePathSet.has(filePath)) return;
+				if (filePath === canvasFile.path) return;
+				const targetFile = getFilePath(filePath);
+				if (!targetFile) return;
+				linksToRemove.push(toLink(filePath, targetFile));
+			});
+
+			// Only add the link when the edge is still present in the canvas data —
+			// the debounced sync may run after the edge was already deleted again.
+			let linkToAdd: string | null = null;
+			if (toNode.filePath && fromNode.filePath !== toNode.filePath && edgeToNodesFilePathSet.has(toNode.filePath)) {
+				const targetFile = getFilePath(toNode.filePath);
+				if (targetFile) linkToAdd = toLink(toNode.filePath, targetFile);
+			}
+
+			// Early skip via the metadata cache so a clean canvas open issues no
+			// writes. The cache lags right after a write, so it only gates the
+			// call — the actual add/remove decisions are made against the real
+			// frontmatter inside processFrontMatter below.
 			const cachedLinks = frontmatterValueToArray(
 				this.app.metadataCache.getFileCache(fromFile)?.frontmatter?.[canvasName]
 			);
+			const cacheOutOfDate =
+				linksToRemove.some(link => cachedLinks.includes(link)) ||
+				(linkToAdd !== null && !cachedLinks.includes(linkToAdd));
+			if (!cacheOutOfDate) return;
 
-			fromNodeLinks.forEach(filePath => {
-				if (!edgeToNodesFilePathSet.has(filePath)) {
-					if (filePath === e.canvas.view.file.path) return;
-					const targetFile = getFilePath(filePath);
-					if (!targetFile) return;
+			await this.app.fileManager.processFrontMatter(fromFile, (fm) => {
+				const existingValue = Reflect.get(fm, canvasName);
+				const wasString = typeof existingValue === 'string' && existingValue.trim() !== '';
+				const removeSet = new Set(linksToRemove);
+				const next = frontmatterValueToArray(existingValue).filter(link => !removeSet.has(link));
+				if (linkToAdd && !next.includes(linkToAdd)) next.push(linkToAdd);
 
-					const link = this.app.fileManager.generateMarkdownLink(targetFile, filePath).replace(/^!(\[\[.*\]\])$/, '$1');
-					if (!cachedLinks.includes(link)) return;
-					updatePromises.push(this.updateFrontmatter(fromFile, link, 'remove', canvasName));
+				if (next.length > 0) {
+					Reflect.set(fm, canvasName, next.length === 1 && wasString ? next[0] : next);
+				} else {
+					Reflect.deleteProperty(fm, canvasName);
 				}
+
+				ensureCanvasKeyOrder(fm, [canvasName]);
 			});
-
-			if (toNode?.filePath) {
-				if (fromNode.filePath !== toNode.filePath) {
-					const targetFile = getFilePath(toNode.filePath);
-
-					if (targetFile) {
-						const link = this.app.fileManager.generateMarkdownLink(targetFile, toNode.filePath).replace(/^!(\[\[.*\]\])$/, '$1');
-						if (!cachedLinks.includes(link)) {
-							updatePromises.push(this.updateFrontmatter(fromFile, link, 'add', canvasName));
-						}
-					}
-				}
-			}
-
-			await Promise.all(updatePromises);
 		};
 
 		// Edges touched within the debounce window all get processed; repeated
-		// updates of the same edge collapse into one slot.
+		// updates of the same edge collapse into one slot. Opening a canvas
+		// re-adds every edge, so the addEdge patch queues here too: the flush
+		// then runs after the import finishes, against complete canvas data —
+		// an immediate sync would reconcile against partially imported edges
+		// and strip links that are still being loaded.
 		const pendingEdgeUpdates = new Set<CanvasEdge>();
 		const flushEdgeUpdates = debounce(() => {
 			const pending = Array.from(pendingEdgeUpdates);
@@ -950,10 +1012,6 @@ export default class EnhancedCanvas extends Plugin {
 
 			pendingEdgeUpdates.add(e);
 			flushEdgeUpdates();
-		};
-
-		const updateTargetNodeImmediate = async (e: CanvasEdge) => {
-			await processNodeUpdate(e);
 		};
 
 		/**
@@ -1090,7 +1148,8 @@ export default class EnhancedCanvas extends Plugin {
 					return function(this: Canvas, edge: CanvasEdge) {
 						const result = old.call(this, edge);
 						selfPatched(edge);
-						void updateTargetNodeImmediate(edge);
+						pendingEdgeUpdates.add(edge);
+						flushEdgeUpdates();
 						return result;
 					};
 				},

--- a/main.ts
+++ b/main.ts
@@ -63,9 +63,6 @@ export default class EnhancedCanvas extends Plugin {
 	private isMetadataClicked = false;
 	settings: EnhancedCanvasSettings;
 
-	private autoHeightCheckReference: (() => void) | null = null;
-	private autoLinkCheckReference: (() => void) | null = null;
-	private dragTempNodeCheckReference: (() => void) | null = null;
 	public canvasStackInterval: number | null = null;
 	public autoHeightUninstaller: (() => void) | null = null;
 	public dragTempNodeUninstaller: (() => void) | null = null;
@@ -481,6 +478,31 @@ export default class EnhancedCanvas extends Plugin {
 		} else {
 			activeDocument.body.classList.remove('enhanced-canvas-enabled');
 		}
+	}
+
+	/**
+	 * Patching Canvas internals needs a live Canvas leaf, which may not exist
+	 * at load time. Runs `patch` now and again on every workspace change that
+	 * could introduce one, until it reports success — then detaches the retry
+	 * listeners so the patch can't run twice (see CLAUDE.md). The listeners
+	 * are also registered for unload cleanup, so a patch that never succeeds
+	 * leaks nothing.
+	 */
+	registerLazyPatcher(patch: () => boolean) {
+		let patched = false;
+		const tryToPatch = () => {
+			if (patched || !patch()) return;
+			patched = true;
+			this.app.workspace.offref(leafEvent);
+			this.app.workspace.offref(layoutEvent);
+		};
+
+		const leafEvent = this.app.workspace.on('active-leaf-change', tryToPatch);
+		const layoutEvent = this.app.workspace.on('layout-change', tryToPatch);
+		this.registerEvent(leafEvent);
+		this.registerEvent(layoutEvent);
+		this.app.workspace.onLayoutReady(tryToPatch);
+		tryToPatch();
 	}
 
 	/**
@@ -1088,19 +1110,8 @@ export default class EnhancedCanvas extends Plugin {
 			canvasPatched = true;
 			return true;
 		};
-		
-		const tryToPatch = () => {
-			if (patchCanvas()) {
-				this.detachAutoLinkListeners();
-			}
-		};
-		this.autoLinkCheckReference = tryToPatch;
 
-		this.app.workspace.on('active-leaf-change', tryToPatch);
-		this.app.workspace.on('layout-change', tryToPatch);
-		this.app.workspace.onLayoutReady(tryToPatch);
-
-		tryToPatch();
+		this.registerLazyPatcher(patchCanvas);
 	}
 
 	registerCanvasExploder() {
@@ -1131,17 +1142,14 @@ export default class EnhancedCanvas extends Plugin {
     patchCanvasNodeMenu() {
         // eslint-disable-next-line @typescript-eslint/no-this-alias -- alias needed: `this` inside the around() patch rebinds to the Canvas node, so the plugin reference must be captured in an outer variable
         const plugin = this;
-        let patched = false;
-        
-        const tryPatch = () => {
-            if (patched) return;
-            
+
+        this.registerLazyPatcher(() => {
             const canvasView = this.app.workspace.getLeavesOfType("canvas")?.[0]?.view as CanvasView | undefined;
             const anyNode = canvasView?.canvas?.nodes?.values()?.next()?.value;
-            if (!anyNode) return;
+            if (!anyNode) return false;
 
             const basePrototype = Object.getPrototypeOf(Object.getPrototypeOf(anyNode));
-            if (!basePrototype?.showMenu) return;
+            if (!basePrototype?.showMenu) return false;
 
             const uninstall = around(basePrototype, {
                 showMenu: (next: (menu: Menu, ...args: unknown[]) => unknown) => {
@@ -1159,13 +1167,8 @@ export default class EnhancedCanvas extends Plugin {
             });
 
             this.register(uninstall);
-            patched = true;
-            plugin.app.workspace.offref(leafEvent);
-        };
-
-        const leafEvent = this.app.workspace.on('active-leaf-change', tryPatch);
-        this.app.workspace.onLayoutReady(tryPatch);
-        this.registerEvent(leafEvent);
+            return true;
+        });
     }
 	
 	/**
@@ -1280,36 +1283,7 @@ export default class EnhancedCanvas extends Plugin {
     }
 
 	registerCanvasNodeAutoHeightPatcher() {
-		const tryToPatch = () => {
-			const success = this.patchCanvasNodeAutoHeight();
-
-			if (success) {
-				this.detachAutoHeightPatcherListeners();
-			}
-		};
-		this.autoHeightCheckReference = tryToPatch;
-
-		this.app.workspace.on('active-leaf-change', tryToPatch);
-		this.app.workspace.on('layout-change', tryToPatch);
-		this.app.workspace.onLayoutReady(tryToPatch);
-
-		tryToPatch();
-	}
-
-	private detachAutoHeightPatcherListeners() {
-		if (this.autoHeightCheckReference) {
-			this.app.workspace.off('active-leaf-change', this.autoHeightCheckReference);
-			this.app.workspace.off('layout-change', this.autoHeightCheckReference);
-			this.autoHeightCheckReference = null;
-		}
-	}
-
-	private detachAutoLinkListeners() {
-		if (this.autoLinkCheckReference) {
-			this.app.workspace.off('active-leaf-change', this.autoLinkCheckReference);
-			this.app.workspace.off('layout-change', this.autoLinkCheckReference);
-			this.autoLinkCheckReference = null;
-		}
+		this.registerLazyPatcher(() => this.patchCanvasNodeAutoHeight());
 	}
 
 	/**
@@ -1377,25 +1351,7 @@ export default class EnhancedCanvas extends Plugin {
 	}
 
 	registerCanvasDragTempNodePatcher() {
-		const tryToPatch = () => {
-			if (this.patchCanvasDragTempNode()) {
-				this.detachDragTempNodeListeners();
-			}
-		};
-		this.dragTempNodeCheckReference = tryToPatch;
-
-		this.app.workspace.on('active-leaf-change', tryToPatch);
-		this.app.workspace.on('layout-change',     tryToPatch);
-		this.app.workspace.onLayoutReady(tryToPatch);
-		tryToPatch();
-	}
-
-	private detachDragTempNodeListeners() {
-		if (this.dragTempNodeCheckReference) {
-			this.app.workspace.off('active-leaf-change', this.dragTempNodeCheckReference);
-			this.app.workspace.off('layout-change', this.dragTempNodeCheckReference);
-			this.dragTempNodeCheckReference = null;
-		}
+		this.registerLazyPatcher(() => this.patchCanvasDragTempNode());
 	}
 
 	createEdge(
@@ -1450,9 +1406,6 @@ export default class EnhancedCanvas extends Plugin {
 		}
 
 		activeDocument.body.classList.remove('enhanced-canvas-enabled');
-		this.detachAutoHeightPatcherListeners();
-		this.detachAutoLinkListeners();
-		this.detachDragTempNodeListeners();
 
 		this.sendToCanvas.clearSelectedCanvas(false);
 		void this.cleanupCanvasProperties();

--- a/src/CanvasExploder.ts
+++ b/src/CanvasExploder.ts
@@ -171,7 +171,8 @@ export class CanvasExploder {
 		const newEdgesData: CanvasEdgeData[] = [];
 
 		let createdCount = 0;
-		const originalData = canvas.getData().nodes.find((n: CanvasNodeData) => n.id === originalNode.id) ?? ({} as Partial<CanvasNodeData>);
+		const currentData = canvas.getData();
+		const originalData = currentData.nodes.find((n: CanvasNodeData) => n.id === originalNode.id) ?? ({} as Partial<CanvasNodeData>);
 
 		for (let i = 0; i < headings.length; i++) {
 			const heading = headings[i];
@@ -242,7 +243,6 @@ export class CanvasExploder {
 		}
 
 		if (createdCount > 0) {
-			const currentData = canvas.getData();
 			currentData.nodes = currentData.nodes.filter((n: CanvasNodeData) => n.id !== originalNode.id);
 			currentData.edges = currentData.edges.filter((e: CanvasEdgeData) =>
 				e.fromNode !== originalNode.id && e.toNode !== originalNode.id
@@ -290,7 +290,8 @@ export class CanvasExploder {
 		const width = Math.max(originalWidth, DEFAULT_WIDTH);
 		const minLevel = Math.min(...sections.map(s => s.level));
 
-		const originalData = canvas.getData().nodes.find((n: CanvasNodeData) => n.id === originalNodeId) ?? ({} as Partial<CanvasNodeData>);
+		const currentData = canvas.getData();
+		const originalData = currentData.nodes.find((n: CanvasNodeData) => n.id === originalNodeId) ?? ({} as Partial<CanvasNodeData>);
 
 		// --- 2. Build new nodes and edges data ---
 		let currentY = baseY;
@@ -370,8 +371,6 @@ export class CanvasExploder {
 		}
 
 		// --- 3. Apply all changes ---
-		const currentData = canvas.getData();
-		
 		// Remove original node from data
 		currentData.nodes = currentData.nodes.filter((n: CanvasNodeData) => n.id !== originalNodeId);
 

--- a/src/CanvasExploder.ts
+++ b/src/CanvasExploder.ts
@@ -146,7 +146,7 @@ export class CanvasExploder {
 	 * Deconstructs a single file node into a hierarchical tree of connected nodes representing its internal headings,
 	 * replacing the original node to visualize the document's structure directly on the canvas.
 	 */
-	async explodeFileNode(canvas: Canvas, originalNode: CanvasNode) {
+	explodeFileNode(canvas: Canvas, originalNode: CanvasNode) {
 		const targetFile = originalNode.file;
 		if (!targetFile) return;
 
@@ -156,160 +156,59 @@ export class CanvasExploder {
 			return;
 		}
 
-		const headings = cache.headings;
-		const isCompactMode = headings.length > HEADING_LIMIT;
-
-		const baseX = originalNode.x;
-		let currentY = originalNode.y;
-
-		const width = Math.max(originalNode.width ?? 0, DEFAULT_WIDTH);
-
-		const minLevel = Math.min(...headings.map((h) => h.level));
-
-		const nodeStack: { level: number, nodeId: string }[] = [];
-		const newNodesData: AllCanvasNodeData[] = [];
-		const newEdgesData: CanvasEdgeData[] = [];
-
-		let createdCount = 0;
-		const currentData = canvas.getData();
-		const originalData = currentData.nodes.find((n: CanvasNodeData) => n.id === originalNode.id) ?? ({} as Partial<CanvasNodeData>);
-
-		for (let i = 0; i < headings.length; i++) {
-			const heading = headings[i];
-			
-			const nextHeading = headings[i + 1];
-			const isParent = nextHeading && nextHeading.level > heading.level;
-
-			let nodeHeight: number;
-			if (isParent) {
-				nodeHeight = COMPACT_HEIGHT;
-			}
-			else if (isCompactMode) {
-				nodeHeight = LEAF_HEIGHT;
-			}
-			else {
-				nodeHeight = (typeof originalNode.height === 'number' && originalNode.height > COMPACT_HEIGHT)
-					? Math.min(MAX_HEIGHT, originalNode.height)
-					: COMPACT_HEIGHT;
-			}
-
-			const levelOffset = heading.level - minLevel;
-			const currentX = baseX + (levelOffset * (width + GAP_X));
-
-			const cleanText = this.sanitizeHeading(heading.heading);
-			const subpath = `#${cleanText}`;
-
-			const newNodeId = randomId();
-			newNodesData.push({
-				...originalData,
-				id: newNodeId,
+		const createdCount = this.buildSectionTree(
+			canvas,
+			originalNode,
+			cache.headings,
+			(heading) => ({
 				type: 'file',
 				file: targetFile.path,
-				subpath: subpath,
-				x: currentX,
-				y: currentY,
-				width: width,
-				height: nodeHeight
-			});
-
-			createdCount++;
-
-			while (nodeStack.length > 0) {
-				const lastEntry = nodeStack[nodeStack.length - 1];
-				if (lastEntry.level >= heading.level) {
-					nodeStack.pop();
-				} else {
-					break;
-				}
-			}
-
-			if (nodeStack.length > 0) {
-				const parentEntry = nodeStack[nodeStack.length - 1];
-				newEdgesData.push({
-					id: randomId(),
-					fromNode: parentEntry.nodeId,
-					fromSide: 'bottom',
-					toNode: newNodeId,
-					toSide: 'left'
-				});
-			}
-
-			nodeStack.push({
-				level: heading.level,
-				nodeId: newNodeId
-			});
-
-			currentY += nodeHeight + GAP_Y;
-		}
-
-		if (createdCount > 0) {
-			currentData.nodes = currentData.nodes.filter((n: CanvasNodeData) => n.id !== originalNode.id);
-			currentData.edges = currentData.edges.filter((e: CanvasEdgeData) =>
-				e.fromNode !== originalNode.id && e.toNode !== originalNode.id
-			);
-
-			currentData.nodes.push(...newNodesData);
-			currentData.edges.push(...newEdgesData);
-			
-			canvas.setData(currentData);
-			canvas.requestSave(false);
-
-			const newNodeIds = new Set(newNodesData.map(n => n.id));
-			canvas.deselectAll();
-			for (const [id, node] of canvas.nodes) {
-				if (newNodeIds.has(id)) {
-					canvas.select(node);
-				}
-			}
-			canvas.zoomToSelection();
-		}
+				subpath: `#${this.sanitizeHeading(heading.heading)}`,
+			}),
+			COMPACT_HEIGHT,
+		);
 
 		new Notice(`Explosion complete, created ${createdCount} nodes.`);
 	}
 
 	/**
-	 * Deconstructs a single text node into a hierarchical tree of connected nodes representing its internal headings,
-	 * replacing the original node to visualize the card's structure directly on the canvas.
+	 * Shared explode core: lays out one node per section (indented by heading
+	 * level), connects each section to its nearest shallower parent, then swaps
+	 * the original node for the new tree and selects it.
+	 *
+	 * @param nodePayload - Per-section node fields (e.g. file+subpath, or text).
+	 * @param fallbackLeafHeight - Leaf height when the original node has no usable height.
+	 * @returns The number of nodes created.
 	 */
-	async explodeTextNode(canvas: Canvas, originalNode: CanvasNode) {
-		const rawText = originalNode.text ?? '';
-		const sections = this.parseMarkdownHeadings(rawText);
+	private buildSectionTree<S extends { level: number }>(
+		canvas: Canvas,
+		originalNode: CanvasNode,
+		sections: S[],
+		nodePayload: (section: S) => Partial<AllCanvasNodeData>,
+		fallbackLeafHeight: number,
+	): number {
+		const isCompactMode = sections.length > HEADING_LIMIT;
 
-		if (sections.length === 0) {
-			new Notice("No headings found to split.");
-			return;
-		}
-
-		// --- 1. Cache original node properties ---
 		const baseX = originalNode.x;
-		const baseY = originalNode.y;
-		const originalWidth = originalNode.width ?? 0;
+		let currentY = originalNode.y;
 		const originalHeight = originalNode.height;
-		const originalNodeId = originalNode.id;
 
-		const width = Math.max(originalWidth, DEFAULT_WIDTH);
-		const minLevel = Math.min(...sections.map(s => s.level));
+		const width = Math.max(originalNode.width ?? 0, DEFAULT_WIDTH);
+		const minLevel = Math.min(...sections.map((s) => s.level));
 
 		const currentData = canvas.getData();
-		const originalData = currentData.nodes.find((n: CanvasNodeData) => n.id === originalNodeId) ?? ({} as Partial<CanvasNodeData>);
+		const originalData = currentData.nodes.find((n: CanvasNodeData) => n.id === originalNode.id) ?? ({} as Partial<CanvasNodeData>);
 
-		// --- 2. Build new nodes and edges data ---
-		let currentY = baseY;
 		const nodeStack: { level: number, nodeId: string }[] = [];
 		const newNodesData: AllCanvasNodeData[] = [];
 		const newEdgesData: CanvasEdgeData[] = [];
 
 		for (let i = 0; i < sections.length; i++) {
 			const section = sections[i];
-			
-			// Check if this is a parent node
+
 			const nextSection = sections[i + 1];
 			const isParent = nextSection && nextSection.level > section.level;
-			
-			// Determine if we're in compact mode (many sections)
-			const isCompactMode = sections.length > HEADING_LIMIT;
-			
-			// Calculate height
+
 			let nodeHeight: number;
 			if (isParent) {
 				nodeHeight = COMPACT_HEIGHT;
@@ -318,27 +217,23 @@ export class CanvasExploder {
 			} else {
 				nodeHeight = (typeof originalHeight === 'number' && originalHeight > COMPACT_HEIGHT)
 					? Math.min(MAX_HEIGHT, originalHeight)
-					: LEAF_HEIGHT;
+					: fallbackLeafHeight;
 			}
-			
-			// Calculate position
+
 			const levelOffset = section.level - minLevel;
 			const currentX = baseX + (levelOffset * (width + GAP_X));
 
-			// Create node data (not the actual node yet)
 			const newNodeId = randomId();
 			newNodesData.push({
 				...originalData,
+				...nodePayload(section),
 				id: newNodeId,
-				type: 'text',
-				text: section.content,
 				x: currentX,
 				y: currentY,
 				width: width,
 				height: nodeHeight
-			});
+			} as AllCanvasNodeData);
 
-			// Manage Hierarchy
 			while (nodeStack.length > 0) {
 				const lastEntry = nodeStack[nodeStack.length - 1];
 				if (lastEntry.level >= section.level) {
@@ -348,7 +243,6 @@ export class CanvasExploder {
 				}
 			}
 
-			// Add Edge if parent exists
 			if (nodeStack.length > 0) {
 				const parentEntry = nodeStack[nodeStack.length - 1];
 				newEdgesData.push({
@@ -360,33 +254,25 @@ export class CanvasExploder {
 				});
 			}
 
-			// Push current node to stack
 			nodeStack.push({
 				level: section.level,
 				nodeId: newNodeId
 			});
 
-			// Update Y position
 			currentY += nodeHeight + GAP_Y;
 		}
 
-		// --- 3. Apply all changes ---
-		// Remove original node from data
-		currentData.nodes = currentData.nodes.filter((n: CanvasNodeData) => n.id !== originalNodeId);
-
-		// Remove any edges connected to original node
+		currentData.nodes = currentData.nodes.filter((n: CanvasNodeData) => n.id !== originalNode.id);
 		currentData.edges = currentData.edges.filter((e: CanvasEdgeData) =>
-			e.fromNode !== originalNodeId && e.toNode !== originalNodeId
+			e.fromNode !== originalNode.id && e.toNode !== originalNode.id
 		);
-		
-		// Add new nodes and edges
+
 		currentData.nodes.push(...newNodesData);
 		currentData.edges.push(...newEdgesData);
-		
+
 		canvas.setData(currentData);
 		canvas.requestSave(false);
 
-		// --- 4. Select new nodes ---
 		const newNodeIds = new Set(newNodesData.map(n => n.id));
 		canvas.deselectAll();
 		for (const [id, node] of canvas.nodes) {
@@ -396,6 +282,32 @@ export class CanvasExploder {
 		}
 		canvas.zoomToSelection();
 
-		new Notice(`Split complete, created ${sections.length} cards.`);
+		return newNodesData.length;
+	}
+
+	/**
+	 * Deconstructs a single text node into a hierarchical tree of connected nodes representing its internal headings,
+	 * replacing the original node to visualize the card's structure directly on the canvas.
+	 */
+	explodeTextNode(canvas: Canvas, originalNode: CanvasNode) {
+		const sections = this.parseMarkdownHeadings(originalNode.text ?? '');
+
+		if (sections.length === 0) {
+			new Notice("No headings found to split.");
+			return;
+		}
+
+		const createdCount = this.buildSectionTree(
+			canvas,
+			originalNode,
+			sections,
+			(section) => ({
+				type: 'text',
+				text: section.content,
+			}),
+			LEAF_HEIGHT,
+		);
+
+		new Notice(`Split complete, created ${createdCount} cards.`);
 	}
 }

--- a/src/CanvasTagImport.ts
+++ b/src/CanvasTagImport.ts
@@ -1,5 +1,4 @@
 import {
-    EventRef,
     ItemView,
     Menu,
 } from "obsidian";
@@ -22,27 +21,13 @@ export class CanvasTagImport {
     private plugin: EnhancedCanvas;
     private patched = false;
     private menus = new WeakSet<Menu>();
-    private leafEvent: EventRef | null = null;
-    private layoutEvent: EventRef | null = null;
 
     constructor(plugin: EnhancedCanvas) {
         this.plugin = plugin;
     }
 
     register(): void {
-        const tryToPatch = () => {
-            if (this.patchCanvasCreationMenu()) {
-                this.detachPatchListeners();
-            }
-        };
-
-        this.leafEvent = this.plugin.app.workspace.on("active-leaf-change", tryToPatch);
-        this.layoutEvent = this.plugin.app.workspace.on("layout-change", tryToPatch);
-
-        this.plugin.registerEvent(this.leafEvent);
-        this.plugin.registerEvent(this.layoutEvent);
-        this.plugin.app.workspace.onLayoutReady(tryToPatch);
-        tryToPatch();
+        this.plugin.registerLazyPatcher(() => this.patchCanvasCreationMenu());
     }
 
     private patchCanvasCreationMenu(): boolean {
@@ -67,18 +52,6 @@ export class CanvasTagImport {
         plugin.register(uninstall);
         this.patched = true;
         return true;
-    }
-
-    private detachPatchListeners(): void {
-        if (this.leafEvent) {
-            this.plugin.app.workspace.offref(this.leafEvent);
-            this.leafEvent = null;
-        }
-
-        if (this.layoutEvent) {
-            this.plugin.app.workspace.offref(this.layoutEvent);
-            this.layoutEvent = null;
-        }
     }
 
     private getAnyCanvas(): Canvas | null {


### PR DESCRIPTION
## Summary

This PR consolidates frontmatter synchronization logic into a single `syncAllCanvasProperties()` method and introduces a reusable `registerLazyPatcher()` helper to eliminate boilerplate across all prototype patching code. The changes improve maintainability, reduce duplication, and optimize frontmatter writes by diffing against the metadata cache before updating.

## Key Changes

- **New `syncAllCanvasProperties()` method**: Replaces the inline canvas-walking loop in `onload()`. Aggregates desired frontmatter state across all canvases, diffs against the metadata cache, and performs at most one `processFrontMatter` write per out-of-date note (zero writes when already up-to-date).

- **New `registerLazyPatcher()` helper**: Centralizes the pattern of retrying a patch function on workspace layout changes until success, then detaching listeners. Eliminates ~40 lines of duplicated listener management code across `registerCanvasAutoLinkPatcher()`, `patchCanvasNodeMenu()`, `registerCanvasNodeAutoHeightPatcher()`, `registerCanvasDragTempNodePatcher()`, and `CanvasTagImport.register()`.

- **Helper functions for frontmatter normalization**: Added `frontmatterValueToArray()` to normalize missing/string/array frontmatter values, and `escapeRegExp()` to safely embed file names in regex patterns (fixes potential regex injection in link detection).

- **Optimized edge update tracking**: Replaced immediate `processNodeUpdate()` calls with a debounced batch that tracks edge connectivity changes, avoiding redundant frontmatter writes when edges move geometrically but don't change endpoints.

- **Performance improvements in node lookups**: Replaced repeated `.find()` calls with `Map` lookups in `optimizeEdgesBetweenSelectedNodes()`, `syncAllCanvasProperties()`, and edge update handlers.

- **Removed unused state**: Deleted `patchedEdge`, `autoHeightCheckReference`, `autoLinkCheckReference`, `dragTempNodeCheckReference`, and `_delayedResizeTimer` interface field.

- **Simplified command callbacks**: Removed unused `canvasData` parameter from `ifActiveViewIsCanvas()` callback signature.

- **CanvasExploder refactoring**: Extracted shared tree-building logic into `buildSectionTree()` to eliminate duplication between `explodeFileNode()` and `explodeTextNode()`. Made both methods synchronous (removed `async`).

- **Updated CLAUDE.md**: Documented the new `syncAllCanvasProperties()` startup sweep and `registerLazyPatcher()` pattern.

## Implementation Details

- Frontmatter cache checks prevent writes when properties are already up-to-date, which is the common case on restart.
- Edge connectivity tracking uses a `WeakMap` to avoid memory leaks; the first sighting of an edge is the baseline (new edges are already synced by the `addEdge` patch).
- The `buildSectionTree()` abstraction accepts a `nodePayload` callback, allowing file and text nodes to share layout logic while providing different node data.
- All lazy patcher registrations now use the centralized helper, ensuring consistent listener cleanup and preventing re-patching bugs.

https://claude.ai/code/session_01QzXABj7ffpQohca1WkJmBE