### PR TITLE
fix: skip uninitialised pinned canvas leaf when patching

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -535,7 +535,16 @@ export default class EnhancedCanvas extends Plugin {
 		const layoutEvent = this.app.workspace.on('layout-change', tryToPatch);
 		this.registerEvent(leafEvent);
 		this.registerEvent(layoutEvent);
-		this.app.workspace.onLayoutReady(tryToPatch);
+		this.app.workspace.onLayoutReady(() => {
+			tryToPatch();
+			// A pinned canvas tab on Windows may not have .canvas initialised when
+			// onLayoutReady fires (the Canvas plugin finishes async after layout).
+			// Retry with backoff so we catch it without relying on a tab-switch.
+			for (const delay of [500, 1500, 4000]) {
+				const t = window.setTimeout(tryToPatch, delay);
+				this.register(() => window.clearTimeout(t));
+			}
+		});
 		tryToPatch();
 	}
 

--- a/main.ts
+++ b/main.ts
@@ -535,16 +535,7 @@ export default class EnhancedCanvas extends Plugin {
 		const layoutEvent = this.app.workspace.on('layout-change', tryToPatch);
 		this.registerEvent(leafEvent);
 		this.registerEvent(layoutEvent);
-		this.app.workspace.onLayoutReady(() => {
-			tryToPatch();
-			// A pinned canvas tab on Windows may not have .canvas initialised when
-			// onLayoutReady fires (the Canvas plugin finishes async after layout).
-			// Retry with backoff so we catch it without relying on a tab-switch.
-			for (const delay of [500, 1500, 4000]) {
-				const t = window.setTimeout(tryToPatch, delay);
-				this.register(() => window.clearTimeout(t));
-			}
-		});
+		this.app.workspace.onLayoutReady(tryToPatch);
 		tryToPatch();
 	}
 
@@ -1124,7 +1115,8 @@ export default class EnhancedCanvas extends Plugin {
 		const patchCanvas = () => {
 			if (canvasPatched) return false;
 
-			const canvasView = this.app.workspace.getLeavesOfType('canvas')[0]?.view as CanvasView | undefined;
+			const canvasView = this.app.workspace.getLeavesOfType('canvas')
+				.find(l => (l.view as CanvasView)?.canvas != null)?.view as CanvasView | undefined;
 			if (!canvasView?.canvas) return false;
 
 			const uninstaller = around(canvasView.canvas.constructor.prototype, {
@@ -1212,7 +1204,8 @@ export default class EnhancedCanvas extends Plugin {
         const plugin = this;
 
         this.registerLazyPatcher(() => {
-            const canvasView = this.app.workspace.getLeavesOfType("canvas")?.[0]?.view as CanvasView | undefined;
+            const canvasView = this.app.workspace.getLeavesOfType("canvas")
+                .find(l => (l.view as CanvasView)?.canvas?.nodes?.size)?.view as CanvasView | undefined;
             const anyNode = canvasView?.canvas?.nodes?.values()?.next()?.value;
             if (!anyNode) return false;
 


### PR DESCRIPTION
## Summary

- `getLeavesOfType('canvas')[0]` always returns the pinned tab, whose `.canvas` is `null` if it was never activated. Even opening a new canvas tab (which lands at index `[1]`) didn't help because the patcher always looked at `[0]`.
- `patchCanvas` and `patchCanvasNodeMenu` both had this bug, so `addNode`/`removeNode` patches were never applied — frontmatter was never updated when adding or dragging nodes into a canvas.

## Changes

- **`patchCanvas`**: replaced `[0]` with `.find(l => l.view.canvas != null)` to skip uninitialised leaves and use the first ready canvas.
- **`patchCanvasNodeMenu`**: same fix, using `.find(l => l.view.canvas?.nodes?.size)` to find a canvas that already has nodes (needed to access the node prototype).

## Test plan

- [ ] Pin a canvas tab, do **not** click it, then open a new canvas tab
- [ ] Drag a markdown note into the new canvas → frontmatter should update
- [ ] Right-click a node in the new canvas → node menu should appear correctly
- [ ] Verify the pinned canvas tab still works normally after activating it

---
_Generated by [Claude Code](https://claude.ai/code/session_01CiHPq8m3H9UDScwkdeMv59)_